### PR TITLE
Demo event propagation quirks

### DIFF
--- a/tests/dummy/app/components/dropzone-container.js
+++ b/tests/dummy/app/components/dropzone-container.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+
+export default Ember.Component.extend({
+  actions: {
+    logDragleave() {
+      console.log('called ondragleave');
+    }
+  }
+});

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -28,3 +28,11 @@
 .dropzone.hovered {
   background: lightpink;
 }
+
+.nestedDropzone {
+  background: blue;
+}
+
+.nestedDropzone.hovered {
+  height: 40px;
+}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -20,20 +20,15 @@
       >
       <h3>{{column.name}}</h3>
       {{#each (get this column.property) as |card|}}
-        <div class="card" 
+        {{#dropzone-container card=card dragging=dragging}}
+        <div class="card"
              draggable="true"
              ondragstart={{action (pipe (action (mut dragging) card) (action (mut from) (get this column.property)))}}
              ondragend={{action (pipe (action (mut dragging) null) (action (mut from) null))}}>
           <h3>{{card.title}}</h3>
           <p>{{card.description}}</p>
         </div>
-
-        <div class="dropzone {{if (and (eq hovered card) (not (eq dragging card))) 'hovered'}}"
-          ondrop={{action (pipe (prevent-default) (stop-propagation) (action 'after' dragging from (get this column.property) hovered) (action (mut hovered) null))}}
-          ondragenter={{action (mut hovered) card}}
-          ondragleave={{action (mut hovered) null}}
-        >
-        </div>
+        {{/dropzone-container}}
       {{/each}}
     </div>
   {{/each}}

--- a/tests/dummy/app/templates/components/dropzone-container.hbs
+++ b/tests/dummy/app/templates/components/dropzone-container.hbs
@@ -1,0 +1,14 @@
+<section
+  ondragenter={{action (mut hovered) dragging}}
+  ondragleave={{action (pipe (action (mut hovered) null) (action 'logDragleave'))}}
+>
+<div class="nestedDropzone {{if (and hovered (not-eq card hovered)) 'hovered'}}"
+  ondragleave={{action (stop-propagation)}}
+>
+</div>
+<div ondragleave={{action (stop-propagation)}}>{{yield}}</div>
+<div class="nestedDropzone {{if (and hovered (not-eq card hovered)) 'hovered'}}"
+  ondragleave={{action (stop-propagation)}}
+>
+</div>
+</section>


### PR DESCRIPTION
I'm unable to reproduce the animation flickering, but I think the issue is similar to what is shown here. 

Am I using `(stop-propagation)` correctly? My understanding is that it should block child events from propagating into parent handlers. So dragging into the blue areas shouldn't trigger the log action. I also don't know why dragging into the bottom area changes the state.

![aug-19-2016 15-54-35](https://cloud.githubusercontent.com/assets/312446/17826559/ccf02f58-6626-11e6-8904-526260c31861.gif)
